### PR TITLE
Add signature separator

### DIFF
--- a/public/jsx/signature.js
+++ b/public/jsx/signature.js
@@ -16,6 +16,7 @@ define(["react"], function (React) {
                     "color":"#333",
                     "lineHeight": "1.6em"
                 }}>
+                    <div className="separator" style={{"display": "block"}}>--&nbsp;</div>
                     <strong style={{"display": "block"}}>{this.props.name}</strong>
                     <em style={{
                         "display": "block",


### PR DESCRIPTION
Usenet and email conventions recommend that the signature "be delimited
from the body of the message by a single line consisting of exactly two
hyphens, followed by a space, followed by the end of line."

It helps email clients to hide or delete the signature when replying.
