### PR TITLE
Add footer selection and German legal info footer to generator 

### DIFF
--- a/public/javascript/defaults.js
+++ b/public/javascript/defaults.js
@@ -7,6 +7,7 @@ define([], function () {
         "name": "Thought Worker",
         "title": "Consultant",
         "email": "tworker@thoughtworks.com",
-        "telephone": "+1 234 567 8910"
+        "telephone": "+1 234 567 8910",
+        "footer": "noFooter"
     };
 });

--- a/public/javascript/email_signature_generator.js
+++ b/public/javascript/email_signature_generator.js
@@ -5,8 +5,9 @@ define([
     "jsx!../jsx/email_signature_generator",
     "properties",
     "themes",
+    "footers",
     "defaults"
-], function (React, EmailSignatureGenerator, properties, themes, defaults) {
+], function (React, EmailSignatureGenerator, properties, themes, footers, defaults) {
     "use strict";
     return function (rootElement, staticAssetsUrl) {
         React.renderComponent(new EmailSignatureGenerator({
@@ -15,6 +16,8 @@ define([
             "themes": themes(staticAssetsUrl),
             "language": defaults.language,
             "theme": defaults.theme,
+            "footers": footers(),
+            "footer": defaults.footer,
             "name": defaults.name,
             "title": defaults.title,
             "email": defaults.email,

--- a/public/javascript/footers.js
+++ b/public/javascript/footers.js
@@ -1,0 +1,17 @@
+/* global define */
+define([], function () {
+    "use strict";
+    return function () {
+        return {
+            "noFooter": {
+                "firstLine": null,
+                "secondLine": null
+            },
+            "germanLegalFooter": {
+                // Do not translate these two strings - they are required by German law to be in German
+                "firstLine": "ThoughtWorks Deutschland GmbH - Großer Burstah 46-48 - D-20457 Hamburg",
+                "secondLine": "Sitz der Gesellschaft: Hamburg - Geschäftsführer: Dr. Peter Buhrmann - AG Hamburg - HRB 115336"
+            }
+        };
+    };
+});

--- a/public/javascript/properties.js
+++ b/public/javascript/properties.js
@@ -2,6 +2,9 @@
 /* jshint -W100 */
 define([], function () {
     "use strict";
+    // Do not translate these two strings - they are required by German law to be in German
+    var legalFooterGermanyAddress = "ThoughtWorks Deutschland GmbH - Großer Burstah 46-48 - D-20457 Hamburg";
+    var legalFooterGermanyInfo = "Sitz der Gesellschaft: Hamburg - Geschäftsführer: Dr. Peter Buhrmann - AG Hamburg - HRB 115336"
     return {
         "en": {
             "languageLabel": "Language",
@@ -18,6 +21,10 @@ define([], function () {
             "titleLabel": "Title",
             "emailLabel": "Email",
             "telephoneLabel": "Telephone",
+            "legalFooterGermanyLabel": "Add legal footer for Germany?",
+            "legalFooterGermanyDescription": "Only mandatory for employees on German payroll",
+            "legalFooterGermanyAddress": legalFooterGermanyAddress,
+            "legalFooterGermanyInfo": legalFooterGermanyInfo,
             "themeLabel": "Theme",
             "black": "Black",
             "blue": "Blue",
@@ -54,6 +61,10 @@ define([], function () {
             "titleLabel": "头衔",
             "emailLabel": "邮箱",
             "telephoneLabel": "电话",
+            "legalFooterGermanyLabel": "Add legal footer for Germany?", // TODO Translate
+            "legalFooterGermanyDescription": "Only mandatory for employees on German payroll", // TODO Translate
+            "legalFooterGermanyAddress": legalFooterGermanyAddress,
+            "legalFooterGermanyInfo": legalFooterGermanyInfo,
             "themeLabel": "主题",
             "black": "黑色",
             "blue": "蓝色",
@@ -90,6 +101,10 @@ define([], function () {
             "titleLabel": "Posición",
             "emailLabel": "Correo",
             "telephoneLabel": "Teléfono",
+            "legalFooterGermanyLabel": "Añadir pie de página legal de Alemania?",
+            "legalFooterGermanyDescription": "Sólo obligatorio para los empleados en nómina alemana",
+            "legalFooterGermanyAddress": legalFooterGermanyAddress,
+            "legalFooterGermanyInfo": legalFooterGermanyInfo,
             "themeLabel": "Tema",
             "black": "Negro",
             "blue": "Azul",
@@ -126,6 +141,10 @@ define([], function () {
             "titleLabel": "Posição",
             "emailLabel": "Email",
             "telephoneLabel": "Telefone",
+            "legalFooterGermanyLabel": "Add legal footer for Germany?", // TODO Translate
+            "legalFooterGermanyDescription": "Only mandatory for employees on German payroll", // TODO Translate
+            "legalFooterGermanyAddress": legalFooterGermanyAddress,
+            "legalFooterGermanyInfo": legalFooterGermanyInfo,
             "themeLabel": "Tema",
             "black": "Preto",
             "blue": "Azul",
@@ -162,6 +181,10 @@ define([], function () {
             "titleLabel": "Position",
             "emailLabel": "Email",
             "telephoneLabel": "Telefon",
+            "legalFooterGermanyLabel": "Fußzeile für Geschäftsbriefe in Deutschland hinzufügen?",
+            "legalFooterGermanyDescription": "Nur verpflichtend für Angestellte in Deutschland",
+            "legalFooterGermanyAddress": legalFooterGermanyAddress,
+            "legalFooterGermanyInfo": legalFooterGermanyInfo,
             "themeLabel": "Theme",
             "black": "Schwarz",
             "blue": "Blau",

--- a/public/javascript/properties.js
+++ b/public/javascript/properties.js
@@ -2,9 +2,6 @@
 /* jshint -W100 */
 define([], function () {
     "use strict";
-    // Do not translate these two strings - they are required by German law to be in German
-    var legalFooterGermanyAddress = "ThoughtWorks Deutschland GmbH - Großer Burstah 46-48 - D-20457 Hamburg";
-    var legalFooterGermanyInfo = "Sitz der Gesellschaft: Hamburg - Geschäftsführer: Dr. Peter Buhrmann - AG Hamburg - HRB 115336"
     return {
         "en": {
             "languageLabel": "Language",
@@ -21,10 +18,9 @@ define([], function () {
             "titleLabel": "Title",
             "emailLabel": "Email",
             "telephoneLabel": "Telephone",
-            "legalFooterGermanyLabel": "Add legal footer for Germany?",
-            "legalFooterGermanyDescription": "Only mandatory for employees on German payroll",
-            "legalFooterGermanyAddress": legalFooterGermanyAddress,
-            "legalFooterGermanyInfo": legalFooterGermanyInfo,
+            "footerLabel": "Footer",
+            "noFooter": "None",
+            "germanLegalFooter": "German Legal Info",
             "themeLabel": "Theme",
             "black": "Black",
             "blue": "Blue",
@@ -61,10 +57,9 @@ define([], function () {
             "titleLabel": "头衔",
             "emailLabel": "邮箱",
             "telephoneLabel": "电话",
-            "legalFooterGermanyLabel": "Add legal footer for Germany?", // TODO Translate
-            "legalFooterGermanyDescription": "Only mandatory for employees on German payroll", // TODO Translate
-            "legalFooterGermanyAddress": legalFooterGermanyAddress,
-            "legalFooterGermanyInfo": legalFooterGermanyInfo,
+            "footerLabel": "Footer",
+            "noFooter": "None",
+            "germanLegalFooter": "German Legal Info", // TODO Translate
             "themeLabel": "主题",
             "black": "黑色",
             "blue": "蓝色",
@@ -101,10 +96,9 @@ define([], function () {
             "titleLabel": "Posición",
             "emailLabel": "Correo",
             "telephoneLabel": "Teléfono",
-            "legalFooterGermanyLabel": "Añadir pie de página legal de Alemania?",
-            "legalFooterGermanyDescription": "Sólo obligatorio para los empleados en nómina alemana",
-            "legalFooterGermanyAddress": legalFooterGermanyAddress,
-            "legalFooterGermanyInfo": legalFooterGermanyInfo,
+            "footerLabel": "Pie de Página",
+            "noFooter": "None", // TODO Translate
+            "germanLegalFooter": "German Legal Info", // TODO Translate
             "themeLabel": "Tema",
             "black": "Negro",
             "blue": "Azul",
@@ -141,10 +135,9 @@ define([], function () {
             "titleLabel": "Posição",
             "emailLabel": "Email",
             "telephoneLabel": "Telefone",
-            "legalFooterGermanyLabel": "Add legal footer for Germany?", // TODO Translate
-            "legalFooterGermanyDescription": "Only mandatory for employees on German payroll", // TODO Translate
-            "legalFooterGermanyAddress": legalFooterGermanyAddress,
-            "legalFooterGermanyInfo": legalFooterGermanyInfo,
+            "footerLabel": "Footer", // TODO Translate
+            "noFooter": "None", // TODO Translate
+            "germanLegalFooter": "German Legal Info", // TODO Translate
             "themeLabel": "Tema",
             "black": "Preto",
             "blue": "Azul",
@@ -181,10 +174,9 @@ define([], function () {
             "titleLabel": "Position",
             "emailLabel": "Email",
             "telephoneLabel": "Telefon",
-            "legalFooterGermanyLabel": "Fußzeile für Geschäftsbriefe in Deutschland hinzufügen?",
-            "legalFooterGermanyDescription": "Nur verpflichtend für Angestellte in Deutschland",
-            "legalFooterGermanyAddress": legalFooterGermanyAddress,
-            "legalFooterGermanyInfo": legalFooterGermanyInfo,
+            "footerLabel": "Fußzeile",
+            "noFooter": "Keine",
+            "germanLegalFooter": "Angaben für Geschäftsbriefe",
             "themeLabel": "Theme",
             "black": "Schwarz",
             "blue": "Blau",

--- a/public/jsx/checkbox.js
+++ b/public/jsx/checkbox.js
@@ -1,0 +1,39 @@
+/** @jsx React.DOM */
+/* global define */
+define(["react"], function (React) {
+    "use strict";
+    return React.createClass({
+        handleChange: function (event) {
+            this.props.onChange(event.target.value, event);
+        },
+        handleFocus: function (event) {
+            /* global setTimeout */
+            // Timeout added to fix flaky selection persistence on Chrome
+            setTimeout(function () {
+                this.select();
+            }.bind(event.target), 1);
+        },
+        render: function () {
+            return <div style={{"clear": "both",
+                                "float": "none",
+                                "position": "relative"}}>
+                <input
+                    id={this.props.id}
+                    style={{"position": "absolute",
+                            "top": "3px"}}
+                    onFocus={this.handleFocus}
+                    name={this.props.name}
+                    title={this.props.label}
+                    type="checkbox"
+                    value={this.props.value}
+                    onChange={this.handleChange}
+                />
+                <label style={{"display": "block",
+                               "margin-left": "25px"}}
+                       htmlFor={this.props.id}>
+                            {this.props.label}
+                </label>
+            </div>;
+        }
+    });
+});

--- a/public/jsx/checkbox.js
+++ b/public/jsx/checkbox.js
@@ -20,7 +20,8 @@ define(["react"], function (React) {
                 <input
                     id={this.props.id}
                     style={{"position": "absolute",
-                            "top": "3px"}}
+                            "top": "3px",
+                            "width": "auto"}}
                     onFocus={this.handleFocus}
                     name={this.props.name}
                     title={this.props.label}

--- a/public/jsx/email_signature_generator.js
+++ b/public/jsx/email_signature_generator.js
@@ -4,13 +4,11 @@ define([
     "react",
     "jsx!../jsx/select",
     "jsx!../jsx/input",
-    "jsx!../jsx/checkbox",
     "jsx!../jsx/signature"
 ], function (
     React,
     Select,
     Input,
-    Checkbox,
     Signature
 ) {
     "use strict";
@@ -22,7 +20,7 @@ define([
                 title: this.props.title,
                 email: this.props.email,
                 telephone: this.props.telephone,
-                shouldAddLegalFooterGermany: true,
+                footer: this.props.footer,
                 footerFirstLine: this.props.footerFirstLine,
                 footerSecondLine: this.props.footerSecondLine,
                 theme: this.props.theme
@@ -43,15 +41,10 @@ define([
         handleTelephoneChange: function (telephone) {
             this.setState({telephone: telephone});
         },
-        handleLegalFooterGermanyChange: function (shouldAddLegalFooterGermany) {
-            this.setState({shouldAddLegalFooterGermany: !this.state.shouldAddLegalFooterGermany});
-            if (this.state.shouldAddLegalFooterGermany) {
-                this.setState({footerFirstLine: this.props.properties[this.state.language].legalFooterGermanyAddress});
-                this.setState({footerSecondLine: this.props.properties[this.state.language].legalFooterGermanyInfo});
-            } else {
-                this.setState({footerFirstLine: null});
-                this.setState({footerSecondLine: null});
-            }
+        handleFooterChange: function (footer) {
+            this.setState({footer: footer});
+            this.setState({footerFirstLine: this.props.footers[footer].firstLine});
+            this.setState({footerSecondLine: this.props.footers[footer].secondLine});
         },
         handleThemeChange: function (theme) {
             this.setState({theme: theme});
@@ -142,15 +135,19 @@ define([
                             value={this.state.telephone}
                             onChange={this.handleTelephoneChange}
                         />
-                        <Checkbox
-                            id="legalFooterGermany"
-                            label={properties.legalFooterGermanyLabel}
-                            value={this.state.shouldAddLegalFooterGermany}
-                            onChange={this.handleLegalFooterGermanyChange}
+                        <Select
+                            name="footer"
+                            label={properties.footerLabel}
+                            value={this.state.footer}
+                            options={Object.keys(this.props.footers).map(function (footer) {
+                                return {
+                                    "label": properties[footer],
+                                    "value": footer,
+                                    "selected": this.state.footer === footer
+                                };
+                            }.bind(this))}
+                            onChange={this.handleFooterChange}
                         />
-                        <p style={{"font-size": "0.8rem"}}>
-                            {properties.legalFooterGermanyDescription}
-                        </p>
                         <Select
                             className="primary transition"
                             style={{

--- a/public/jsx/email_signature_generator.js
+++ b/public/jsx/email_signature_generator.js
@@ -4,11 +4,13 @@ define([
     "react",
     "jsx!../jsx/select",
     "jsx!../jsx/input",
+    "jsx!../jsx/checkbox",
     "jsx!../jsx/signature"
 ], function (
     React,
     Select,
     Input,
+    Checkbox,
     Signature
 ) {
     "use strict";
@@ -20,6 +22,9 @@ define([
                 title: this.props.title,
                 email: this.props.email,
                 telephone: this.props.telephone,
+                shouldAddLegalFooterGermany: true,
+                footerFirstLine: this.props.footerFirstLine,
+                footerSecondLine: this.props.footerSecondLine,
                 theme: this.props.theme
             };
         },
@@ -37,6 +42,16 @@ define([
         },
         handleTelephoneChange: function (telephone) {
             this.setState({telephone: telephone});
+        },
+        handleLegalFooterGermanyChange: function (shouldAddLegalFooterGermany) {
+            this.setState({shouldAddLegalFooterGermany: !this.state.shouldAddLegalFooterGermany});
+            if (this.state.shouldAddLegalFooterGermany) {
+                this.setState({footerFirstLine: this.props.properties[this.state.language].legalFooterGermanyAddress});
+                this.setState({footerSecondLine: this.props.properties[this.state.language].legalFooterGermanyInfo});
+            } else {
+                this.setState({footerFirstLine: null});
+                this.setState({footerSecondLine: null});
+            }
         },
         handleThemeChange: function (theme) {
             this.setState({theme: theme});
@@ -127,6 +142,15 @@ define([
                             value={this.state.telephone}
                             onChange={this.handleTelephoneChange}
                         />
+                        <Checkbox
+                            id="legalFooterGermany"
+                            label={properties.legalFooterGermanyLabel}
+                            value={this.state.shouldAddLegalFooterGermany}
+                            onChange={this.handleLegalFooterGermanyChange}
+                        />
+                        <p style={{"font-size": "0.8rem"}}>
+                            {properties.legalFooterGermanyDescription}
+                        </p>
                         <Select
                             className="primary transition"
                             style={{
@@ -172,6 +196,8 @@ define([
                                 label: properties.telephoneLabel,
                                 value: this.state.telephone
                             }}
+                            footerFirstLine={this.state.footerFirstLine}
+                            footerSecondLine={this.state.footerSecondLine}
                         />
                         <button
                             className="button primary transition"

--- a/public/jsx/signature.js
+++ b/public/jsx/signature.js
@@ -4,8 +4,8 @@ define(["react"], function (React) {
     "use strict";
     return React.createClass({
         render: function () {
-            return <div className={this.props.className} style={{"float": "left"}}>
-                <table cellSpacing="0" cellPadding="0" border="0" style={{
+            return <div className={this.props.className} style={{
+                    "float": "left",
                     "fontSize": "12px",
                     "fontWeight": "normal",
                     "fontFamily": "OpenSans-Light," +
@@ -15,7 +15,8 @@ define(["react"], function (React) {
                         "'Helvetica Neue'," +
                         "Helvetica," +
                         "Arial," +
-                        "sans-serif",
+                        "sans-serif"}}>
+                <table cellSpacing="0" cellPadding="0" border="0" style={{
                     "lineHeight": "12px"
                 }}>
                     <tr>
@@ -68,6 +69,8 @@ define(["react"], function (React) {
                     /></a></td>
                     </tr>
                 </table>
+                <p style={{"fontSize": "11px", "fontStyle": "italic"}}> {this.props.footerFirstLine} </p>
+                <p style={{"fontSize": "11px", "fontStyle": "italic"}}> {this.props.footerSecondLine} </p>
             </div>;
         }
     });


### PR DESCRIPTION
Hi @andrewshawcare, hi @peckeltw,

these commits add an additional drop down menu for adding an optional two line footer to the  generated signature. New footers can be defined in 'public/javascript/footers.js'.

The first defined footer contains information, which is required to be part of all business communication in Germany (see §35a GmbHG "Angaben auf Geschäftsbriefen"). It contains information about the address of the company (first line of the footer) and information about  the incorporation of the company (second line).

This commit is missing the translations for Spanish, Portuguese and Chinese. These will be added soon. Please also note that the content of the footer must not be translated as the German law requires it to be in German.

For other countries the footer functionality could be reused to add non-legal information about the  company, such a information about company culture or the like.

Would you please review these changes and merge them if you see fit?

Best regards
@cochrane343
